### PR TITLE
Changed aplay to arecord for no sound bug.

### DIFF
--- a/audio_util.py
+++ b/audio_util.py
@@ -3,7 +3,7 @@ import re
 
 def getAudioDeviceByName(name):
 
-	text = subprocess.check_output(['aplay', '-l'])
+	text = subprocess.check_output(['arecord', '-l'])
 	lines = text.splitlines()
 	for line in lines:
 		if name in line:


### PR DESCRIPTION
Line 6, changed aplay to arecord. Allows user to use --audio-device-name in send_video.py params to fix issue where audio inputs via USB did not have persistent card IDs when rebooted.